### PR TITLE
Fix job duplication

### DIFF
--- a/src/getDelayed.js
+++ b/src/getDelayed.js
@@ -1,0 +1,39 @@
+function delayObjectToString(delayed, from) {
+  let add;
+  switch (delayed.unit) {
+    case 's':
+    case 'sec':
+    case 'second':
+    case 'seconds':
+      add = require('date-fns/add_seconds');
+      break;
+    case 'm':
+    case 'min':
+    case 'minute':
+    case 'minutes':
+      add = require('date-fns/add_minutes');
+      break;
+    case 'h':
+    case 'hour':
+    case 'hours':
+      add = require('date-fns/add_hours');
+      break;
+    case 'd':
+    case 'day':
+    case 'days':
+      add = require('date-fns/add_days');
+      break;
+  }
+
+  return add(from, delayed.value).toISOString();
+}
+
+module.exports = function getDelayed(delayed, from = new Date()) {
+  if (delayed == null) {
+    return null;
+  } else if (typeof delayed === 'string') {
+    return delayed;
+  } else if (typeof delayed === 'object') {
+    return delayObjectToString(delayed, from);
+  }
+};

--- a/src/getRetries.js
+++ b/src/getRetries.js
@@ -3,31 +3,17 @@ const defaultRetries = {
   delay: 1000,
 };
 
-module.exports = function getRetries(messageRetries, handlerRetries) {
-  if (messageRetries) {
-    if (typeof messageRetries === 'object' && messageRetries.count) {
+module.exports = function getRetries(retries) {
+  if (retries) {
+    if (typeof retries === 'object' && retries.count) {
       return {
         ...defaultRetries,
-        ...messageRetries,
+        ...retries,
       };
     } else {
       return {
         ...defaultRetries,
-        count: messageRetries,
-      };
-    }
-  }
-
-  if (handlerRetries) {
-    if (typeof handlerRetries === 'object' && handlerRetries.count) {
-      return {
-        ...defaultRetries,
-        ...handlerRetries,
-      };
-    } else {
-      return {
-        ...defaultRetries,
-        count: handlerRetries,
+        count: retries,
       };
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,6 @@ class PubsubQueue {
    * @param {string} queueConfig.topicName - the topic name to listen / publish to
    * @param {string} queueConfig.subscriptionName - the subscription name for the worker
    * @param {string} queueConfig.buriedTopicName - the buried topic, where it sends buried messages to
-   * @param {boolean} queueConfig.workerAckOnStart - if true, worker will ack message before calling handler, and republishes on retry; otherwise, ack on handler success, and nack on retry
-   *
    *
    */
   constructor(GCloudConfiguration = {}, queueConfig = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ class PubsubQueue {
    * @param {string} queueConfig.topicName - the topic name to listen / publish to
    * @param {string} queueConfig.subscriptionName - the subscription name for the worker
    * @param {string} queueConfig.buriedTopicName - the buried topic, where it sends buried messages to
+   * @param {boolean} queueConfig.workerAckOnStart - if true, worker will ack message before calling handler, and republishes on retry; otherwise, ack on handler success, and nack on retry
    *
    *
    */

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -1,32 +1,4 @@
-function delayObjectToString(delayed) {
-  let add;
-  switch (delayed.unit) {
-    case 's':
-    case 'sec':
-    case 'second':
-    case 'seconds':
-      add = require('date-fns/add_seconds');
-      break;
-    case 'm':
-    case 'min':
-    case 'minute':
-    case 'minutes':
-      add = require('date-fns/add_minutes');
-      break;
-    case 'h':
-    case 'hour':
-    case 'hours':
-      add = require('date-fns/add_hours');
-      break;
-    case 'd':
-    case 'day':
-    case 'days':
-      add = require('date-fns/add_days');
-      break;
-  }
-
-  return add(new Date(), delayed.value).toISOString();
-}
+const getDelayed = require('./getDelayed');
 
 class PubsubPublisher {
   constructor(client, topicName) {
@@ -63,11 +35,7 @@ class PubsubPublisher {
     };
 
     if (delayed) {
-      if (typeof delayed === 'string') {
-        attributes.delayed = delayed;
-      } else if (typeof delayed === 'object') {
-        attributes.delayed = delayObjectToString(delayed);
-      }
+      attributes.delayed = getDelayed(delayed);
     }
 
     if (retries) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -27,10 +27,6 @@ class PubsubWorker extends EventEmitter {
   }
 
   async work(handlers, message) {
-    // parse data payload
-    const dataString = message.data.toString('utf8');
-    const data = safeJSONParse(dataString);
-
     // extract relevant attributes
     const { type, delayed } = message.attributes;
 
@@ -52,6 +48,10 @@ class PubsubWorker extends EventEmitter {
     }
 
     const retries = getRetries(message.attributes.retries, handler.retries);
+
+    // parse data payload
+    const dataString = message.data.toString('utf8');
+    const data = safeJSONParse(dataString);
 
     try {
       // send event that we've picked up a job


### PR DESCRIPTION
Changes:
- Allow ack before calling handler to prevent long-running jobs from being duplicated
- Delay payload parsing until necessary
- Fix: error-retry loop ignores handler return values

Notes:
- I made the new behavior opt-in instead of completely replacing the current one, so that it doesn't break existing clients. It's disabled by default.
- I'm not sure what to name the new option (`workerAckOnStart`/`ackOnStart`), if there are better ideas I'd be happy to change it.
- I'm not sure if it should also be in the `queueConfig` parameter or have its own parameter.